### PR TITLE
Retornar api_token no omniauth-nexaas_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ Or install it yourself as:
 
 ## Usage
 
-`OmniAuth::Strategies::NexaasID` is simply a Rack middleware. Read the OmniAuth docs for detailed information: https://github.com/omniauth/omniauth.
+`OmniAuth::Strategies::NexaasID` is simply a Rack middleware. Read the OmniAuth
+docs for detailed information: https://github.com/omniauth/omniauth.
 
-Here's a quick example, adding the middleware to a Rails app in `config/initializers/omniauth.rb`:
+Here's a quick example, adding the middleware to a Rails app in
+`config/initializers/omniauth.rb`:
 
 ```ruby
 Rails.application.config.middleware.use OmniAuth::Builder do
@@ -30,7 +32,8 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 end
 ```
 
-You can optionally specify the URL as an option (useful in case you want to point to Nexaas ID's staging environment):
+You can optionally specify the URL as an option (useful in case you want to
+point to Nexaas ID's staging environment):
 
 ```ruby
 Rails.application.config.middleware.use OmniAuth::Builder do
@@ -40,16 +43,24 @@ end
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run
+`rake spec` to run the tests. You can also run `bin/console` for an interactive
+prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`. To
+release a new version, update the version number in `version.rb`, and then run
+`bundle exec rake release`, which will create a git tag for the version, push
+git commits and tags, and push the `.gem` file to
+[rubygems.org](https://rubygems.org).
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/myfreecomm/omniauth-nexaas_id.
+Bug reports and pull requests are welcome on GitHub at
+https://github.com/myfreecomm/omniauth-nexaas_id/issues.
 
 
 ## License
 
-The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
+The gem is available as open source under the terms of the
+[MIT License](http://opensource.org/licenses/MIT).
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ You can get documentation from:
 - [Installation](https://github.com/myfreecomm/omniauth-nexaas_id/wiki)
 - [Development & Contributing](https://github.com/myfreecomm/omniauth-nexaas_id/wiki/Development-&-Contributing)
 - [Usage](https://github.com/myfreecomm/omniauth-nexaas_id/wiki/Usage)
+- [Example resource explained](https://github.com/myfreecomm/omniauth-nexaas_id/wiki/Returned-resource)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,65 +2,18 @@
 
 Nexaas ID OAuth2 Strategy for OmniAuth.
 
-## Installation
+## Documentation
 
-Add this line to your application's Gemfile:
+You can get documentation from:
 
-```ruby
-gem 'omniauth-nexaas_id'
-```
-
-And then execute:
-
-    $ bundle
-
-Or install it yourself as:
-
-    $ gem install omniauth-nexaas_id
-
-## Usage
-
-`OmniAuth::Strategies::NexaasID` is simply a Rack middleware. Read the OmniAuth
-docs for detailed information: https://github.com/omniauth/omniauth.
-
-Here's a quick example, adding the middleware to a Rails app in
-`config/initializers/omniauth.rb`:
-
-```ruby
-Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :nexaas_id, ENV['NEXAAS_ID_TOKEN'], ENV['NEXAAS_ID_SECRET']
-end
-```
-
-You can optionally specify the URL as an option (useful in case you want to
-point to Nexaas ID's staging environment):
-
-```ruby
-Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :nexaas_id, ENV['NEXAAS_ID_TOKEN'], ENV['NEXAAS_ID_SECRET'], client_options: { site: ENV['NEXAAS_ID_URL'] }
-end
-```
-
-## Development
-
-After checking out the repo, run `bin/setup` to install dependencies. Then, run
-`rake spec` to run the tests. You can also run `bin/console` for an interactive
-prompt that will allow you to experiment.
-
-To install this gem onto your local machine, run `bundle exec rake install`. To
-release a new version, update the version number in `version.rb`, and then run
-`bundle exec rake release`, which will create a git tag for the version, push
-git commits and tags, and push the `.gem` file to
-[rubygems.org](https://rubygems.org).
-
-## Contributing
-
-Bug reports and pull requests are welcome on GitHub at
-https://github.com/myfreecomm/omniauth-nexaas_id/issues.
-
+- [Installation](https://github.com/myfreecomm/omniauth-nexaas_id/wiki)
+- [Development & Contributing](https://github.com/myfreecomm/omniauth-nexaas_id/wiki/Development-&-Contributing)
+- [Usage](https://github.com/myfreecomm/omniauth-nexaas_id/wiki/Usage)
 
 ## License
 
-The gem is available as open source under the terms of the
+This gem is available as open source under the terms of the
 [MIT License](http://opensource.org/licenses/MIT).
 
+License text is
+[here](https://github.com/myfreecomm/omniauth-nexaas_id/wiki/License).

--- a/lib/omniauth/strategies/nexaas_id.rb
+++ b/lib/omniauth/strategies/nexaas_id.rb
@@ -68,8 +68,10 @@ module OmniAuth
       protected
 
       def build_access_token
-        @api_token = request.params['api_token']
-        super
+        if (token = super).params.present?
+          @api_token = token.params['api_token']
+        end
+        token
       end
     end
   end

--- a/lib/omniauth/strategies/nexaas_id.rb
+++ b/lib/omniauth/strategies/nexaas_id.rb
@@ -7,6 +7,13 @@ module OmniAuth
     class NexaasID < OmniAuth::Strategies::OAuth2
       DEFAULT_SCOPE = 'profile invite'.freeze
 
+      attr_reader :api_token
+
+      def initialize(*args)
+        super
+        @api_token = nil
+      end
+
       option :name, :nexaas_id
       option :client_options, site: 'https://id.nexaas.com'
 
@@ -30,9 +37,7 @@ module OmniAuth
       extra do
         {
           raw_info: raw_info,
-          legacy: {
-            api_token: access_token.api_token
-          }
+          legacy: { api_token: api_token }
         }
       end
 
@@ -57,6 +62,13 @@ module OmniAuth
 
       def request_phase
         options[:authorize_params][:scopes] = options['scope'] || DEFAULT_SCOPE
+        super
+      end
+
+      protected
+
+      def build_access_token
+        @api_token = request.params['api_token']
         super
       end
     end

--- a/lib/omniauth/strategies/nexaas_id.rb
+++ b/lib/omniauth/strategies/nexaas_id.rb
@@ -7,11 +7,9 @@ module OmniAuth
     class NexaasID < OmniAuth::Strategies::OAuth2
       DEFAULT_SCOPE = 'profile invite'.freeze
 
-      attr_reader :api_token
-
       def initialize(*args)
-        super
         @api_token = nil
+        super
       end
 
       option :name, :nexaas_id
@@ -37,7 +35,7 @@ module OmniAuth
       extra do
         {
           raw_info: raw_info,
-          legacy: { api_token: api_token }
+          legacy: { api_token: @api_token }
         }
       end
 
@@ -68,7 +66,7 @@ module OmniAuth
       protected
 
       def build_access_token
-        if (token = super).params.present?
+        if (token = super) && token.params
           @api_token = token.params['api_token']
         end
         token

--- a/lib/omniauth/strategies/nexaas_id.rb
+++ b/lib/omniauth/strategies/nexaas_id.rb
@@ -29,8 +29,10 @@ module OmniAuth
 
       extra do
         {
-          'raw_info'  => raw_info,
-          'api_token' => access_token.api_token
+          'raw_info' => raw_info,
+          'legacy'   => {
+            'api_token' => access_token.api_token
+          }
         }
       end
 

--- a/lib/omniauth/strategies/nexaas_id.rb
+++ b/lib/omniauth/strategies/nexaas_id.rb
@@ -29,9 +29,9 @@ module OmniAuth
 
       extra do
         {
-          'raw_info' => raw_info,
-          'legacy'   => {
-            'api_token' => access_token.api_token
+          raw_info: raw_info,
+          legacy: {
+            api_token: access_token.api_token
           }
         }
       end

--- a/lib/omniauth/strategies/nexaas_id.rb
+++ b/lib/omniauth/strategies/nexaas_id.rb
@@ -5,10 +5,10 @@ OmniAuth.config.add_camelization('nexaas_id', 'NexaasID')
 module OmniAuth
   module Strategies
     class NexaasID < OmniAuth::Strategies::OAuth2
-      DEFAULT_SCOPE = 'profile invite'
+      DEFAULT_SCOPE = 'profile invite'.freeze
 
       option :name, :nexaas_id
-      option :client_options, { site: 'https://id.nexaas.com' }
+      option :client_options, site: 'https://id.nexaas.com'
 
       uid do
         raw_info['id']
@@ -29,7 +29,8 @@ module OmniAuth
 
       extra do
         {
-          'raw_info' => raw_info
+          'raw_info'  => raw_info,
+          'api_token' => access_token.api_token
         }
       end
 

--- a/omniauth-nexaas_id.gemspec
+++ b/omniauth-nexaas_id.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "omniauth-nexaas_id"
-  spec.version       = "0.1.1"
+  spec.version       = "0.1.2"
   spec.authors       = ["Rodrigo Tassinari de Oliveira", "Luiz Carlos Buiatte"]
   spec.email         = ["rodrigo@pittlandia.net", "luiz.buiatte@nexaas.com"]
 

--- a/spec/omniauth/strategies/nexaas_id_spec.rb
+++ b/spec/omniauth/strategies/nexaas_id_spec.rb
@@ -11,13 +11,24 @@ describe OmniAuth::Strategies::NexaasID do
   it 'has a default scope' do
     expect(described_class::DEFAULT_SCOPE).to eq('profile invite')
   end
+
   it 'us a subclass of OmniAuth::Strategies::OAuth2' do
     expect(described_class.superclass).to eq(OmniAuth::Strategies::OAuth2)
   end
+
+  it 'has app' do
+    expect(subject.app).to eq('app_id')
+  end
+
   it 'has a name' do
     expect(subject.name).to eq(:nexaas_id)
   end
+
   it 'has a site' do
     expect(subject.options[:client_options][:site]).to eq('https://sandbox.id.nexaas.com')
+  end
+
+  it 'has a nil api_token before build token' do
+    expect(subject.api_token).to be_nil
   end
 end

--- a/spec/omniauth/strategies/nexaas_id_spec.rb
+++ b/spec/omniauth/strategies/nexaas_id_spec.rb
@@ -27,8 +27,4 @@ describe OmniAuth::Strategies::NexaasID do
   it 'has a site' do
     expect(subject.options[:client_options][:site]).to eq('https://sandbox.id.nexaas.com')
   end
-
-  it 'has a nil api_token before build token' do
-    expect(subject.api_token).to be_nil
-  end
 end


### PR DESCRIPTION
[ch18128](https://app.clubhouse.io/nexaas/story/18128)

Solução deduzida a partir do código do método [`get_token`](https://github.com/oauth-xx/oauth2/blob/master/lib/oauth2/strategy/auth_code.rb#L28) da classe `OAuth2::Strategy::AuthCode`, que mescla os parâmetros (que devem incluir `api_token`) para gerar o *token*.